### PR TITLE
bump to gir_ffi 0.14

### DIFF
--- a/atspi.gemspec
+++ b/atspi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "gir_ffi", "~> 0.10.0"
+  spec.add_dependency "gir_ffi", "~> 0.14.0"
   spec.add_dependency "ruby-dbus", "~> 0.11.0"
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "yard", "~> 0.9.12"


### PR DESCRIPTION
seems to be working well. specifically however this makes the gem actually
work on newer glibs where IConv is no longer introspectable and
consequently gir_ffi older than 0.12.0 is falling on their nose when
trying to load iconv.

(this implicitly drops support for ruby older than 2.2)

It'd also be great to get this released asap. "Newer" glib in this case means at least a year or more old and is in fact the glib used in current ubuntu 18.04 LTS